### PR TITLE
[NESC-13] Key of default queryParameters is restored to snake_case

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -192,7 +192,7 @@ var getViewForSwagger2 = function(opts, type){
                     return;
                   }
 
-                  let parameter = `queryParameters['${this.camelCaseName}'] = `;
+                  let parameter = `queryParameters['${this.name}'] = `;
                   if (_.isString(this.default)) {
                     parameter += `'${this.default}';`;
                   } else if (_.isArray(this.default)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #NESC-13
| License       | proprietary
| Doc PR        | n/a
